### PR TITLE
Make `regular` default, add scripting to permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": []
+  "permissions": ["scripting"]
 }

--- a/popup.html
+++ b/popup.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UPD Course Probability Calculator</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 
 <body>
@@ -29,7 +29,7 @@
                     <option value="freshman">Freshman</option>
                     <option value="varsity">Varsity</option>
                     <option value="cadetOfficer">Cadet Officer</option>
-                    <option value="regular">Regular</option>
+                    <option value="regular" selected>Regular</option>
                     <option value="lowPriority">Low Priority</option>
                 </select>
             </div>


### PR DESCRIPTION
Small PR to fix Manifest 3 error + make Regular / `regular` the default option on the dropdown (should eventually be deprecated once this is automated)

Should ideally be stored in `localStorage` or similar -- this may likely not persist over sessions